### PR TITLE
Add N prefixing for unicode character strings to enable unicode support

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -34,6 +34,10 @@ var sql = {
 
       return " ";
     });
+    
+    if (/[^\u0000-\u00ff]/.test(val)) {
+      return "N'" + val + "'";
+    }
 
     return "'" + val + "'";
   },


### PR DESCRIPTION
This code used to be present, and was removed during one of the code cleanup/reorgs from a branch that I merged in. With this code missing, unicode characters were being replaced by `?????` in the database, which is obviously not correct. This adds unicode string support back in.

## From a bug report:

Some data being saved:

```javascript
{
  "input": {
    "source": {
      "type": "upload",
      "documentId": "panamacanal1",
      "displayName": "几种比较难处理的客户.doc"
    }
  }
}
```

We see this error in the logs:

```
[Error (E_UNKNOWN) Encountered an unexpected error] Details:  Error: ER_TRUNCATED_WRONG_VALUE_FOR_FIELD: Incorrect string value: '\\xE5\\x87\\xA0\\xE7\\xA7\\x8D...' for column 'processJson' at row 1
```

> In SQL Server the issue is also present even though nvarchar is specified for the columns due to the fact that we are not prefixing the unicode-containing strings with "N" when inserting into the table, resulting in them being treated as varchar and stored as question marks ("?????")